### PR TITLE
feat: bump aws-cdk to 2.1128.0 / aws-cdk-lib to 2.260.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   runtime risk: npm's HTTP client is not exercised by the `cdk` entrypoint. Tracking an upstream
   npm bump as the durable fix.
 
+### Changed
+- AWS CDK CLI: 2.1124.1 → **2.1128.0**
+- aws-cdk-lib: 2.257.0 → **2.260.0**
+
 ## [2026-05-25] - `pkumaschow/cdk:latest`, `gitlab.homelab.com:5050/peterk/cdk:latest`
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN NPM_VERSION=$(npm view npm version) && \
     mv /tmp/npm-latest /usr/local/lib/node_modules/npm
 
 # Install AWS CDK v2 CLI
-RUN npm install -g aws-cdk@2.1124.1
+RUN npm install -g aws-cdk@2.1128.0
 
 # Patch nested vulnerable deps that aws-cdk vendors inside its own node_modules — npm upgrades
 # alone do not cover these bundled copies. Each is replaced in-place with the latest published
@@ -42,7 +42,7 @@ RUN for pkg in picomatch brace-expansion ip-address; do \
 # wheel and setuptools upgraded explicitly to fix CVE-2026-24049 (path traversal in wheel.cli.unpack)
 # urllib3>=2.7.0 pinned to fix CVE-2026-44431, CVE-2026-44432 (pulled in as awscli dep)
 RUN pip3 install --no-cache-dir --break-system-packages \
-    aws-cdk-lib==2.257.0 \
+    aws-cdk-lib==2.260.0 \
     constructs \
     awscli \
     'urllib3>=2.7.0' && \


### PR DESCRIPTION
Bump AWS CDK to the latest release.

- aws-cdk CLI: 2.1124.1 → **2.1128.0**
- aws-cdk-lib: 2.257.0 → **2.260.0**

Image rebuilt locally and verified: `cdk --version` → `2.1128.0 (build 7daa104)`, `aws-cdk-lib` → `2.260.0`. Builds on top of the CVE-refresh patches already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
