### PR TITLE
security: OpenVEX exception for CVE-2025-60876 (busybox wget)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -79,6 +79,7 @@ jobs:
           to-env: production
           ignore-unchanged: true
           only-severities: critical,high
+          vex-location: ./.vex
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # main: record CVEs against the production environment after push
@@ -90,4 +91,5 @@ jobs:
           command: cves
           image: pkumaschow/cdk:latest
           only-severities: critical,high
+          vex-location: ./.vex
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.vex/cve-2025-60876.openvex.json
+++ b/.vex/cve-2025-60876.openvex.json
@@ -1,0 +1,24 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/pkumaschow/cdk/.vex/cve-2025-60876",
+  "author": "Peter Kumaschow (pkumaschow)",
+  "role": "Image maintainer",
+  "timestamp": "2026-06-22T12:17:07Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-60876",
+        "description": "BusyBox wget accepts raw CR/LF/C0 control bytes in the HTTP request-target, allowing request-line splitting / header injection (CVSS 6.5, MEDIUM)."
+      },
+      "products": [
+        { "@id": "pkg:docker/pkumaschow/cdk" },
+        { "@id": "pkg:docker/peterk/cdk?repository_url=gitlab.homelab.com%3A5050" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "The image entrypoint is the Node-based aws-cdk CLI; BusyBox wget is never invoked at runtime. The only wget usage is at build time, fetching fixed registry.npmjs.org URLs that are not attacker-controlled. No fixed busybox exists in any Alpine branch as of 2026-06-22; the Dockerfile already runs `apk upgrade`, so the fix applies automatically once Alpine ships it.",
+      "action_statement": "Remove this statement once Alpine publishes a patched busybox -r release and a rebuild clears the finding."
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2026-06-23]
+
+### Security
+- Added an accepted-risk exception (OpenVEX, `.vex/cve-2025-60876.openvex.json`) for
+  **CVE-2025-60876** — BusyBox `wget` request-line splitting / header injection (MEDIUM, CVSS 6.5).
+  Status `not_affected` / `vulnerable_code_not_in_execute_path`: the cdk entrypoint never invokes
+  BusyBox `wget`, and the only build-time `wget` use fetches fixed `registry.npmjs.org` URLs. **No
+  fixed busybox exists in any Alpine branch yet** — the Dockerfile's `apk upgrade` will clear it
+  automatically once Alpine ships a patch. The VEX is consumed by the Scout GitHub action via
+  `vex-location`. Remove the statement once a fixed busybox lands.
+
 ## [2026-06-22] - `pkumaschow/cdk:latest`, `gitlab.homelab.com:5050/peterk/cdk:latest`
 
 ### Security


### PR DESCRIPTION
Add an accepted-risk **OpenVEX** exception for **CVE-2025-60876** (BusyBox `wget` request-line splitting / header injection, MEDIUM, CVSS 6.5).

- `.vex/cve-2025-60876.openvex.json` — status `not_affected`, justification `vulnerable_code_not_in_execute_path`.
- The cdk entrypoint (Node-based aws-cdk CLI) never invokes BusyBox `wget`; the only `wget` use is at build time, fetching fixed `registry.npmjs.org` URLs (not attacker-controlled).
- **No fixed busybox exists in any Alpine branch as of now** (verified via the Alpine security tracker — 3.22/3.23/3.24/edge all "no fix available"). The image already has the newest busybox; the Dockerfile's `apk upgrade` will clear it automatically once Alpine ships a patch.
- Wired into the Docker Scout GitHub action via `vex-location: ./.vex`.

**Note:** this CVE only surfaces in the **Docker Hub Health Score** — both CI gates are scoped to `critical,high`. To drop it from the Health Score grade, the exception also needs to be registered in Docker Scout (dashboard/org) using this same VEX statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
