### PR TITLE
ci: cut Kaniko memory to fix OOMKilled build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,8 @@ build-image:
       --tar-path "${CI_PROJECT_DIR}/image.tar"
       --insecure
       --skip-tls-verify
+      --compressed-caching=false
+      --single-snapshot
   artifacts:
     paths:
       - image.tar


### PR DESCRIPTION
The build-image job was OOMKilled deterministically (twice) building the larger aws-cdk 2.1128.0 image. Add --compressed-caching=false (stop holding compressed layers in RAM) and --single-snapshot (one snapshot at the end) — the standard Kaniko memory-reduction flags.